### PR TITLE
add schema for ProactiveEngagement and DRTAccess

### DIFF
--- a/aws-shield-drtaccess/aws-shield-drtaccess.json
+++ b/aws-shield-drtaccess/aws-shield-drtaccess.json
@@ -1,0 +1,30 @@
+{
+  "typeName": "AWS::Shield::DRTAccess",
+  "description": "Config the role and list of Amazon S3 log buckets used by the Shield Response Team (SRT) to access your AWS account while assisting with attack mitigation.",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-shield.git",
+  "primaryIdentifier": [ "/properties/AccountId" ],
+  "readOnlyProperties": [ "/properties/AccountId" ],
+  "additionalProperties": false,
+  "properties": {
+    "AccountId": {
+      "type": "string"
+    },
+    "LogBucketList": {
+      "description": "Authorizes the Shield Response Team (SRT) to access the specified Amazon S3 bucket containing log data such as Application Load Balancer access logs, CloudFront logs, or logs from third party sources. You can associate up to 10 Amazon S3 buckets with your subscription.",
+      "type": "array",
+      "insertionOrder": false,
+      "minItems": 0,
+      "maxItems": 10,
+      "items": {
+        "type": "string"
+      }
+    },
+    "RoleArn": {
+      "description": "Authorizes the Shield Response Team (SRT) using the specified role, to access your AWS account to assist with DDoS attack mitigation during potential attacks. This enables the SRT to inspect your AWS WAF configuration and create or update AWS WAF rules and web ACLs.",
+      "type": "string"
+    }
+  },
+  "tagging" : {
+    "taggable": false
+  }
+}

--- a/aws-shield-proactiveengagement/aws-shield-proactiveengagement.json
+++ b/aws-shield-proactiveengagement/aws-shield-proactiveengagement.json
@@ -1,0 +1,54 @@
+{
+  "typeName": "AWS::Shield::ProactiveEngagement",
+  "description": "Authorizes the Shield Response Team (SRT) to use email and phone to notify contacts about escalations to the SRT and to initiate proactive customer support.",
+  "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-shield.git",
+  "primaryIdentifier": [ "/properties/AccountId" ],
+  "readOnlyProperties": [ "/properties/AccountId" ],
+  "additionalProperties": false,
+  "required": [
+    "ProactiveEngagementStatus",
+    "EmergencyContactList"
+  ],
+  "properties": {
+    "AccountId": {
+      "type": "string"
+    },
+    "ProactiveEngagementStatus": {
+      "description": "If `ENABLED`, the Shield Response Team (SRT) will use email and phone to notify contacts about escalations to the SRT and to initiate proactive customer support.\nIf `DISABLED`, the SRT will not proactively notify contacts about escalations or to initiate proactive customer support.",
+      "type": "string",
+      "enum": ["ENABLED", "DISABLED"]
+    },
+    "EmergencyContactList": {
+      "description": "A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you for escalations to the SRT and to initiate proactive customer support.\nTo enable proactive engagement, the contact list must include at least one phone number.",
+      "type": "array",
+      "insertionOrder": false,
+      "minItems": 0,
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["EmailAddress"],
+        "properties": {
+          "ContactNotes": {
+            "description": "Additional notes regarding the contact.",
+            "pattern": "^[\\w\\s\\.\\-,:/()+@]*$",
+            "type": "string"
+          },
+          "EmailAddress": {
+            "description": "The email address for the contact.",
+            "pattern": "^\\S+@\\S+\\.\\S+$",
+            "type": "string"
+          },
+          "PhoneNumber": {
+            "description": "The phone number for the contact",
+            "pattern": "^\\+[1-9]\\d{1,14}$",
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tagging" : {
+    "taggable": false
+  }
+}


### PR DESCRIPTION
Adding JSON Schema for following resource types:
- `AWS::Shield::DRTAccess`
- `AWS::Shield::ProactiveEngagement`

Tested with `cfn init && cfn validate`.