### PR TITLE
use HealthCheckArn in protection instead of plain id

### DIFF
--- a/aws-shield-protection/aws-shield-protection.json
+++ b/aws-shield-protection/aws-shield-protection.json
@@ -41,12 +41,13 @@
             "maxLength": 2048,
             "pattern": "^arn:aws.*"
         },
-        "HealthCheckIds": {
-            "description": "The unique identifier (ID) for the Route 53 health check that's associated with the protection.",
+        "HealthCheckArn": {
+            "description": "The Amazon Resource Name (ARN) of the health check to associate with the protection.",
             "type": "array",
             "insertionOrder": false,
             "items": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^arn:aws:route53:::healthcheck/\\S{36}$"
             }
         },
         "ApplicationLayerAutomaticResponseConfiguration": {


### PR DESCRIPTION
use HealthCheckArn in `AWS::Shield::Protection` instead of plain ids