### PR TITLE
Add simple tests for ProtectionGroup handlers to check the pipeline

### DIFF
--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/CreateHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/CreateHandlerTest.java
@@ -1,6 +1,10 @@
 package software.amazon.shield.protectiongroup;
 
-import com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.shield.ShieldClient;
 import software.amazon.awssdk.services.shield.model.CreateProtectionGroupRequest;
 import software.amazon.awssdk.services.shield.model.CreateProtectionGroupResponse;
@@ -9,11 +13,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.shield.protectiongroup.helper.ProtectionGroupTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,27 +34,19 @@ public class CreateHandlerTest {
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class);
+        this.logger = mock(Logger.class);
 
-        createHandler = new CreateHandler(mock(ShieldClient.class));
-        resourceModel =
-                ResourceModel.builder()
-                        .pattern("pattern")
-                        .aggregation("aggregation")
-                        .resourceType("resourceType")
-                        .members(Lists.newArrayList("m1"))
-                        .protectionGroupId("protectionGroupId")
-                        .protectionGroupArn("protectionGroupArn")
-                        .build();
+        this.createHandler = new CreateHandler(mock(ShieldClient.class));
+        this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
         final ResourceHandlerRequest<ResourceModel> request =
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(resourceModel)
-                        .nextToken("nextToken")
+                        .desiredResourceState(this.resourceModel)
+                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
                         .build();
 
         final CreateProtectionGroupResponse createProtectionGroupResponse =
@@ -62,16 +54,15 @@ public class CreateHandlerTest {
                         .build();
 
         doReturn(createProtectionGroupResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(CreateProtectionGroupRequest.class), any());
+                .when(this.proxy).injectCredentialsAndInvokeV2(any(CreateProtectionGroupRequest.class), any());
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
-                createHandler.handleRequest(proxy, request, null, logger);
+                this.createHandler.handleRequest(this.proxy, request, null, this.logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        // assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/DeleteHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/DeleteHandlerTest.java
@@ -1,17 +1,17 @@
 package software.amazon.shield.protectiongroup;
 
-import com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.shield.ShieldClient;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.shield.protectiongroup.helper.ProtectionGroupTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -30,31 +30,23 @@ public class DeleteHandlerTest {
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class);
+        this.logger = mock(Logger.class);
 
-        deleteHandler = new DeleteHandler(mock(ShieldClient.class));
-        resourceModel =
-                ResourceModel.builder()
-                        .pattern("pattern")
-                        .aggregation("aggregation")
-                        .resourceType("resourceType")
-                        .members(Lists.newArrayList("m1"))
-                        .protectionGroupId("protectionGroupId")
-                        .protectionGroupArn("protectionGroupArn")
-                        .build();
+        this.deleteHandler = new DeleteHandler(mock(ShieldClient.class));
+        this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
         final ResourceHandlerRequest<ResourceModel> request =
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(resourceModel)
-                        .nextToken("nextToken")
+                        .desiredResourceState(this.resourceModel)
+                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
                         .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
-                deleteHandler.handleRequest(proxy, request, null, logger);
+                this.deleteHandler.handleRequest(this.proxy, request, null, this.logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/ListHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/ListHandlerTest.java
@@ -1,6 +1,10 @@
 package software.amazon.shield.protectiongroup;
 
-import com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.shield.ShieldClient;
 import software.amazon.awssdk.services.shield.model.ListProtectionGroupsRequest;
 import software.amazon.awssdk.services.shield.model.ListProtectionGroupsResponse;
@@ -9,11 +13,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.shield.protectiongroup.helper.ProtectionGroupTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,27 +34,19 @@ public class ListHandlerTest {
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class);
+        this.logger = mock(Logger.class);
 
-        listHandler = new ListHandler(mock(ShieldClient.class));
-        resourceModel =
-                ResourceModel.builder()
-                        .pattern("pattern")
-                        .aggregation("aggregation")
-                        .resourceType("resourceType")
-                        .members(Lists.newArrayList("m1"))
-                        .protectionGroupId("protectionGroupId")
-                        .protectionGroupArn("protectionGroupArn")
-                        .build();
+        this.listHandler = new ListHandler(mock(ShieldClient.class));
+        this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
         final ResourceHandlerRequest<ResourceModel> request =
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(resourceModel)
-                        .nextToken("nextToken")
+                        .desiredResourceState(this.resourceModel)
+                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
                         .build();
 
         final ListProtectionGroupsResponse listProtectionGroupsResponse =
@@ -62,10 +54,10 @@ public class ListHandlerTest {
                         .build();
 
         doReturn(listProtectionGroupsResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(ListProtectionGroupsRequest.class), any());
+                .when(this.proxy).injectCredentialsAndInvokeV2(any(ListProtectionGroupsRequest.class), any());
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
-                listHandler.handleRequest(proxy, request, null, logger);
+                this.listHandler.handleRequest(this.proxy, request, null, this.logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/ReadHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/ReadHandlerTest.java
@@ -1,19 +1,23 @@
 package software.amazon.shield.protectiongroup;
 
-import com.google.common.collect.Lists;
-import software.amazon.awssdk.services.shield.ShieldClient;
-import software.amazon.awssdk.services.shield.model.CreateProtectionGroupRequest;
-import software.amazon.awssdk.services.shield.model.CreateProtectionGroupResponse;
-import software.amazon.awssdk.services.shield.model.DescribeProtectionGroupResponse;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.shield.ShieldClient;
+import software.amazon.awssdk.services.shield.model.DescribeProtectionGroupRequest;
+import software.amazon.awssdk.services.shield.model.DescribeProtectionGroupResponse;
+import software.amazon.awssdk.services.shield.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.shield.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.shield.model.ProtectionGroup;
+import software.amazon.awssdk.services.shield.model.Tag;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.shield.protectiongroup.helper.ProtectionGroupTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,46 +38,63 @@ public class ReadHandlerTest {
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class);
+        this.logger = mock(Logger.class);
 
-        readHandler = new ReadHandler(mock(ShieldClient.class));
-        resourceModel =
-                ResourceModel.builder()
-                        .protectionGroupArn("protectionGroupArn")
-                        .members(Lists.newArrayList("members"))
-                        .protectionGroupId("protectionGroupId")
-                        .resourceType("resourceType")
-                        .aggregation("aggregation")
-                        .pattern("pattern")
-                        .build();
+        this.readHandler = new ReadHandler(mock(ShieldClient.class));
+        this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
         final ResourceHandlerRequest<ResourceModel> request =
                 ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(resourceModel)
-                        .nextToken("nextToken")
+                        .desiredResourceState(this.resourceModel)
+                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
                         .build();
 
         final DescribeProtectionGroupResponse createProtectionGroupResponse =
                 DescribeProtectionGroupResponse.builder()
+                        .protectionGroup(
+                                ProtectionGroup.builder()
+                                        .protectionGroupId(ProtectionGroupTestData.PROTECTION_GROUP_ID)
+                                        .protectionGroupArn(ProtectionGroupTestData.PROTECTION_GROUP_ARN)
+                                        .resourceType(ProtectionGroupTestData.RESOURCE_TYPE)
+                                        .aggregation(ProtectionGroupTestData.AGGREGATION)
+                                        .pattern(ProtectionGroupTestData.PATTERN)
+                                        .members(ProtectionGroupTestData.MEMBERS)
+                                        .build())
                         .build();
 
         doReturn(createProtectionGroupResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(CreateProtectionGroupRequest.class), any());
+                .when(this.proxy).injectCredentialsAndInvokeV2(any(DescribeProtectionGroupRequest.class), any());
+
+        registerListTags();
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
-                readHandler.handleRequest(proxy, request, null, logger);
+                this.readHandler.handleRequest(this.proxy, request, null, this.logger);
 
-//        assertThat(response).isNotNull();
-//        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-//        assertThat(response.getCallbackContext()).isNull();
-//        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-//        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-//        assertThat(response.getResourceModels()).isNull();
-//        assertThat(response.getMessage()).isNull();
-//        assertThat(response.getErrorCode()).isNull();
+       assertThat(response).isNotNull();
+       assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+       assertThat(response.getCallbackContext()).isNull();
+       assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+       assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+       assertThat(response.getResourceModels()).isNull();
+       assertThat(response.getMessage()).isNull();
+       assertThat(response.getErrorCode()).isNull();
+    }
+
+    private void registerListTags() {
+
+        ListTagsForResourceResponse tagResponse =
+                ListTagsForResourceResponse.builder()
+                        .tags(
+                                Tag.builder().key("k1").value("v1").build(),
+                                Tag.builder().key("k2").value("v2").build())
+                        .build();
+
+        doReturn(tagResponse)
+                .when(this.proxy)
+                .injectCredentialsAndInvokeV2(any(ListTagsForResourceRequest.class), any());
     }
 }

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/UpdateHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/UpdateHandlerTest.java
@@ -1,17 +1,23 @@
 package software.amazon.shield.protectiongroup;
 
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.shield.ShieldClient;
+import software.amazon.awssdk.services.shield.model.UpdateProtectionGroupRequest;
+import software.amazon.awssdk.services.shield.model.UpdateProtectionGroupResponse;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.shield.protectiongroup.helper.ProtectionGroupTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,35 +29,42 @@ public class UpdateHandlerTest {
     @Mock
     private Logger logger;
 
-    private UpdateHandler deleteHandler;
+    private UpdateHandler updateHandler;
     private ResourceModel resourceModel;
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class);
+        this.logger = mock(Logger.class);
+
+        this.updateHandler = new UpdateHandler(mock(ShieldClient.class));
+        this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-//        final UpdateHandler handler = new UpdateHandler();
-//
-//        final ResourceModel model = ResourceModel.builder().build();
-//
-//        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-//            .desiredResourceState(model)
-//            .build();
-//
-//        final ProgressEvent<ResourceModel, CallbackContext> response
-//            = handler.handleRequest(proxy, request, null, logger);
-//
-//        assertThat(response).isNotNull();
-//        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-//        assertThat(response.getCallbackContext()).isNull();
-//        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-//        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-//        assertThat(response.getResourceModels()).isNull();
-//        assertThat(response.getMessage()).isNull();
-//        assertThat(response.getErrorCode()).isNull();
+        final ResourceHandlerRequest<ResourceModel> request =
+                ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(this.resourceModel)
+                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
+                        .build();
+
+        final UpdateProtectionGroupResponse updateProtectionGroupResponse =
+                UpdateProtectionGroupResponse.builder()
+                        .build();
+
+        doReturn(updateProtectionGroupResponse)
+                .when(this.proxy).injectCredentialsAndInvokeV2(any(UpdateProtectionGroupRequest.class), any());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 }

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/helper/ProtectionGroupTestData.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/helper/ProtectionGroupTestData.java
@@ -1,0 +1,37 @@
+package software.amazon.shield.protectiongroup.helper;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import software.amazon.shield.protectiongroup.ResourceModel;
+import software.amazon.shield.protectiongroup.Tag;
+
+public class ProtectionGroupTestData {
+    public static final String NEXT_TOKEN = "TEST_NEXT_TOKEN";
+
+    public static final String PROTECTION_GROUP_ID = "test_protection_group_id";
+    public static final String PROTECTION_GROUP_ARN = "test_protection_group_arn";
+
+    public static final String PATTERN = "test_pattern";
+    public static final String AGGREGATION = "test_aggregation";
+    public static final String RESOURCE_TYPE = "test_resource_type";
+
+    public static final String MEMBER_1 = "test_member_1";
+    public static final String MEMBER_2 = "test_member_2";
+    public static final List<String> MEMBERS = Lists.newArrayList(MEMBER_1, MEMBER_2);
+
+    public static final Tag TAG_1 = Tag.builder().key("k1").value("v1").build();
+    public static final Tag TAG_2 = Tag.builder().key("k2").value("v2").build();
+    public static final List<Tag> TAGS = Lists.newArrayList(TAG_1, TAG_2);
+
+    public static final ResourceModel RESOURCE_MODEL =
+            ResourceModel.builder()
+                    .pattern(PATTERN)
+                    .aggregation(AGGREGATION)
+                    .resourceType(RESOURCE_TYPE)
+                    .members(MEMBERS)
+                    .protectionGroupId(PROTECTION_GROUP_ID)
+                    .protectionGroupArn(PROTECTION_GROUP_ARN)
+                    .tags(TAGS)
+                    .build();
+}


### PR DESCRIPTION
This is the simplest set of tests for each of the ProtectionGroup handlers to check whether the config are done properly for the internal pipeline analyzer process.
More tests will be added later if this passes in the internal pipeline.