### PR TITLE
refine property constraints in schema

### DIFF
--- a/aws-shield-drtaccess/aws-shield-drtaccess.json
+++ b/aws-shield-drtaccess/aws-shield-drtaccess.json
@@ -21,15 +21,13 @@
       "items": {
         "type": "string",
         "minLength": 3,
-        "maxLength": 63,
-        "pattern": "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$"
+        "maxLength": 63
       }
     },
     "RoleArn": {
       "description": "Authorizes the Shield Response Team (SRT) using the specified role, to access your AWS account to assist with DDoS attack mitigation during potential attacks. This enables the SRT to inspect your AWS WAF configuration and create or update AWS WAF rules and web ACLs.",
       "type": "string",
-      "maxLength": 2048,
-      "pattern": "^arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+      "maxLength": 2048
     }
   },
   "handlers": {

--- a/aws-shield-protection/aws-shield-protection.json
+++ b/aws-shield-protection/aws-shield-protection.json
@@ -36,8 +36,7 @@
       "description": "The ARN (Amazon Resource Name) of the resource to be protected.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 2048,
-      "pattern": "^arn:aws.*"
+      "maxLength": 2048
     },
     "HealthCheckArns": {
       "description": "The Amazon Resource Names (ARNs) of the health check to associate with the protection.",
@@ -46,8 +45,7 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 2048,
-        "pattern": "^arn:aws:route53:::healthcheck/\\S{36}$"
+        "maxLength": 2048
       }
     },
     "ApplicationLayerAutomaticResponseConfiguration": {

--- a/aws-shield-protectiongroup/aws-shield-protectiongroup.json
+++ b/aws-shield-protectiongroup/aws-shield-protectiongroup.json
@@ -41,8 +41,7 @@
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 2048,
-        "pattern": "^arn:aws.*"
+        "maxLength": 2048
       }
     },
     "ResourceType": {


### PR DESCRIPTION
*Description of changes:*

Went through the [API doc](https://docs.aws.amazon.com/waf/latest/DDOSAPIReference/Welcome.html) one more time, and filled in some loosing bits in schema. Mainly regex patterns on string fields.

Note: didn't change Subscription as it may not be included in the first release

======

Update:
Remove regex patterns for ARNs since `cfn validate` displays the following message:

```
Don't hardcode the aws partition in ARN patterns: ^arn:aws:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+
Resource schema is valid.
```