### PR TITLE
fix protection schema

### DIFF
--- a/aws-shield-protection/aws-shield-protection.json
+++ b/aws-shield-protection/aws-shield-protection.json
@@ -42,10 +42,11 @@
       "description": "The Amazon Resource Names (ARNs) of the health check to associate with the protection.",
       "type": "array",
       "insertionOrder": false,
+      "maxItems": 1,
       "items": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 1
+        "maxLength": 2048
       }
     },
     "ApplicationLayerAutomaticResponseConfiguration": {


### PR DESCRIPTION
Fixed a mistake in https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-shield/commit/0c8008edaa38588ec155a4ccd6f0844f6c3263ff

Where I intended to set maxItems on the array, but I mistakenly set the maxLength on the string value.