### PR TITLE
various bugfixes for Protection type

### DIFF
--- a/aws-shield-protection/src/main/java/software/amazon/shield/protection/UpdateHandler.java
+++ b/aws-shield-protection/src/main/java/software/amazon/shield/protection/UpdateHandler.java
@@ -1,8 +1,14 @@
 package software.amazon.shield.protection;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -10,26 +16,26 @@ import software.amazon.awssdk.services.shield.ShieldClient;
 import software.amazon.awssdk.services.shield.model.AssociateHealthCheckRequest;
 import software.amazon.awssdk.services.shield.model.BlockAction;
 import software.amazon.awssdk.services.shield.model.CountAction;
-import software.amazon.awssdk.services.shield.model.DescribeProtectionRequest;
 import software.amazon.awssdk.services.shield.model.DisableApplicationLayerAutomaticResponseRequest;
 import software.amazon.awssdk.services.shield.model.DisassociateHealthCheckRequest;
 import software.amazon.awssdk.services.shield.model.EnableApplicationLayerAutomaticResponseRequest;
-import software.amazon.awssdk.services.shield.model.Protection;
 import software.amazon.awssdk.services.shield.model.ResponseAction;
+import software.amazon.awssdk.services.shield.model.TagResourceRequest;
+import software.amazon.awssdk.services.shield.model.UntagResourceRequest;
+import software.amazon.awssdk.services.shield.model.UpdateApplicationLayerAutomaticResponseRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.shield.common.CustomerAPIClientBuilder;
 import software.amazon.shield.common.ExceptionConverter;
+import software.amazon.shield.common.HandlerHelper;
 
 @RequiredArgsConstructor
 public class UpdateHandler extends BaseHandler<CallbackContext> {
 
     private final ShieldClient client;
-
-    private static final String healthCheckArnTemplate = "arn:aws:route53:::healthcheck/";
 
     public UpdateHandler() {
         this.client = CustomerAPIClientBuilder.getClient();
@@ -42,31 +48,39 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        final ResourceModel model = request.getDesiredResourceState();
-        final String protectionArn = model.getProtectionArn();
-        final String protectionId = model.getProtectionId();
+        final ResourceModel currentState = request.getPreviousResourceState();
+        final ResourceModel desiredState = request.getDesiredResourceState();
+        final String protectionArn = desiredState.getProtectionArn();
+        final String protectionId = HandlerHelper.protectionArnToId(protectionArn);
         logger.log(String.format("UpdateHandler: protection arn = %s", protectionArn));
         logger.log(String.format("UpdateHandler: protection id = %s", protectionId));
 
         try {
-            final Protection protection = proxy
-                .injectCredentialsAndInvokeV2(DescribeProtectionRequest.builder()
-                    .protectionId(model.getProtectionId())
-                    .build(), this.client::describeProtection)
-                .protection();
+            updateHealthCheckAssociation(
+                desiredState.getHealthCheckArns(),
+                currentState.getHealthCheckArns(),
+                protectionId,
+                proxy
+            );
 
-            // 1. associate/disassociate healthChecks
-            updateHealthCheckAssociation(model, protection, proxy);
-
-            // 2. appLayerAutoResponseConfig
             updateAppLayerAutoResponseConfig(
-                model.getApplicationLayerAutomaticResponseConfiguration(),
-                model.getResourceArn(),
-                proxy);
+                desiredState.getApplicationLayerAutomaticResponseConfiguration(),
+                currentState.getApplicationLayerAutomaticResponseConfiguration(),
+                currentState.getResourceArn(),
+                proxy
+            );
+
+            updateTags(
+                desiredState.getTags(),
+                currentState.getTags(),
+                protectionArn,
+                proxy
+            );
 
             return readProtection(protectionArn, proxy, logger);
 
         } catch (RuntimeException e) {
+            logger.log(String.format("UpdateHandler: error %s", e));
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .status(OperationStatus.FAILED)
                 .errorCode(ExceptionConverter.convertToErrorCode(e))
@@ -75,36 +89,79 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         }
     }
 
-    private void updateHealthCheckAssociation(
-        @NonNull final ResourceModel model,
-        @NonNull final Protection protection,
+    private void updateTags(
+        @Nullable final List<Tag> desiredTags,
+        @Nullable final List<Tag> currentTags,
+        @NonNull final String protectionArn,
         @NonNull final AmazonWebServicesClientProxy proxy) {
 
-        final Set<String> healthCheckArnsBefore =
-            protection.healthCheckIds()
-                .stream()
-                .map(x -> healthCheckArnTemplate + x)
-                .collect(Collectors.toSet());
+        final Map<String, String> currentTagsMap = Optional.ofNullable(currentTags)
+            .orElse(Collections.emptyList())
+            .stream()
+            .collect(Collectors.toMap(
+                Tag::getKey,
+                Tag::getValue
+            ));
 
-        final Set<String> healthCheckArnsAfter = new HashSet<>(model.getHealthCheckArns());
+        final List<software.amazon.awssdk.services.shield.model.Tag> tagsToSet = new ArrayList<>();
 
-        final Set<String> intersection =
-            healthCheckArnsBefore
-                .stream()
-                .filter(healthCheckArnsAfter::contains)
-                .collect(Collectors.toSet());
+        Optional.ofNullable(desiredTags).orElse(Collections.emptyList()).forEach(tag -> {
+            if (!(tag.getValue().equals(currentTagsMap.get(tag.getKey())))) {
+                tagsToSet.add(software.amazon.awssdk.services.shield.model.Tag.builder()
+                    .key(tag.getKey())
+                    .value(tag.getValue())
+                    .build());
+            }
+            currentTagsMap.remove(tag.getKey());
+        });
+
+        final List<String> tagsToRemove = new ArrayList<>(currentTagsMap.keySet());
+
+        if (tagsToSet.size() > 0) {
+            proxy.injectCredentialsAndInvokeV2(TagResourceRequest.builder()
+                .tags(tagsToSet)
+                .resourceARN(protectionArn)
+                .build(), this.client::tagResource);
+        }
+
+        if (tagsToRemove.size() > 0) {
+            proxy.injectCredentialsAndInvokeV2(UntagResourceRequest.builder()
+                .tagKeys(tagsToRemove)
+                .resourceARN(protectionArn)
+                .build(), this.client::untagResource);
+        }
+    }
+
+    private void updateHealthCheckAssociation(
+        @Nullable final List<String> desiredHealthCheckArns,
+        @Nullable final List<String> currentHealthCheckArns,
+        @NonNull final String protectionId,
+        @NonNull final AmazonWebServicesClientProxy proxy) {
+
+        final Set<String> healthCheckArnsBefore = new HashSet<>(
+            Optional.ofNullable(currentHealthCheckArns)
+                .orElse(Collections.emptyList())
+        );
+
+        final Set<String> healthCheckArnsAfter = new HashSet<>(
+            Optional.ofNullable(desiredHealthCheckArns)
+                .orElse(Collections.emptyList())
+        );
+
+        final Set<String> intersection = new HashSet<>(healthCheckArnsBefore);
+        intersection.retainAll(healthCheckArnsAfter);
 
         healthCheckArnsBefore.removeAll(intersection);
         healthCheckArnsAfter.removeAll(intersection);
 
-        associateHealthChecks(protection.id(), healthCheckArnsAfter, proxy);
-        disassociateHealthChecks(protection.id(), healthCheckArnsBefore, proxy);
+        associateHealthChecks(protectionId, healthCheckArnsAfter, proxy);
+        disassociateHealthChecks(protectionId, healthCheckArnsBefore, proxy);
     }
 
     private void associateHealthChecks(
         @NonNull final String protectionId,
-        final Set<String> healthCheckArns,
-        final AmazonWebServicesClientProxy proxy) {
+        @NonNull final Set<String> healthCheckArns,
+        @NonNull final AmazonWebServicesClientProxy proxy) {
 
         healthCheckArns.forEach(
             arn -> {
@@ -123,8 +180,8 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
     private void disassociateHealthChecks(
         @NonNull final String protectionId,
-        final Set<String> healthCheckArns,
-        final AmazonWebServicesClientProxy proxy) {
+        @NonNull final Set<String> healthCheckArns,
+        @NonNull final AmazonWebServicesClientProxy proxy) {
 
         healthCheckArns.forEach(
             arn -> {
@@ -142,60 +199,84 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
     }
 
     private void updateAppLayerAutoResponseConfig(
-        final ApplicationLayerAutomaticResponseConfiguration config,
+        @Nullable final ApplicationLayerAutomaticResponseConfiguration desiredConfig,
+        @Nullable final ApplicationLayerAutomaticResponseConfiguration currentConfig,
         @NonNull final String resourceArn,
         @NonNull final AmazonWebServicesClientProxy proxy) {
 
-        if (config.getStatus().equals("ENABLED")) {
-            if (config.getAction().getBlock() != null) {
-                enableAppLayerAutoResponseWithBlockAction(resourceArn, proxy);
-            } else {
-                enableAppLayerAutoResponseWithCountAction(resourceArn, proxy);
-            }
-        } else {
-            disableAppLayerAutoResponse(resourceArn, proxy);
+        final String desiredStatus = Optional.ofNullable(desiredConfig)
+            .map(software.amazon.shield.protection.ApplicationLayerAutomaticResponseConfiguration::getStatus)
+            .orElse("DISABLED");
+
+        final String currentStatus = Optional.ofNullable(currentConfig)
+            .map(software.amazon.shield.protection.ApplicationLayerAutomaticResponseConfiguration::getStatus)
+            .orElse("DISABLED");
+
+        final boolean desiredActionIsBlock = Optional.ofNullable(desiredConfig)
+            .map(ApplicationLayerAutomaticResponseConfiguration::getAction)
+            .map(Action::getBlock)
+            .isPresent();
+
+        final boolean currentActionIsBlock = Optional.ofNullable(currentConfig)
+            .map(ApplicationLayerAutomaticResponseConfiguration::getAction)
+            .map(Action::getBlock)
+            .isPresent();
+
+        // case 1: state unchanged
+        // case 1.1: remain disabled
+        if (desiredStatus.equals("DISABLED") && currentStatus.equals("DISABLED")) {
+            return;
         }
-    }
-
-    private void enableAppLayerAutoResponseWithBlockAction(
-        @NonNull final String resourceArn,
-        @NonNull final AmazonWebServicesClientProxy proxy) {
-
-        proxy.injectCredentialsAndInvokeV2(
-            EnableApplicationLayerAutomaticResponseRequest.builder()
-                .resourceArn(resourceArn)
-                .action(
-                    ResponseAction.builder()
-                        .block(BlockAction.builder().build())
-                        .build())
-                .build(),
-            this.client::enableApplicationLayerAutomaticResponse);
-    }
-
-    private void enableAppLayerAutoResponseWithCountAction(
-        @NonNull final String resourceArn,
-        @NonNull final AmazonWebServicesClientProxy proxy) {
-
-        proxy.injectCredentialsAndInvokeV2(
-            EnableApplicationLayerAutomaticResponseRequest.builder()
-                .resourceArn(resourceArn)
-                .action(
-                    ResponseAction.builder()
-                        .count(CountAction.builder().build())
-                        .build())
-                .build(),
-            this.client::enableApplicationLayerAutomaticResponse);
-    }
-
-    private void disableAppLayerAutoResponse(
-        @NonNull final String resourceArn,
-        @NonNull final AmazonWebServicesClientProxy proxy) {
-
-        proxy.injectCredentialsAndInvokeV2(
-            DisableApplicationLayerAutomaticResponseRequest.builder()
-                .resourceArn(resourceArn)
-                .build(),
-            this.client::disableApplicationLayerAutomaticResponse);
+        // case 1.2: remain enabled (however the action may have changed)
+        else if (
+            desiredStatus.equals("ENABLED") && currentStatus.equals("ENABLED")
+        ) {
+            if (desiredActionIsBlock == currentActionIsBlock) {
+                return;
+            }
+            proxy.injectCredentialsAndInvokeV2(
+                UpdateApplicationLayerAutomaticResponseRequest.builder()
+                    .resourceArn(resourceArn)
+                    .action(
+                        desiredActionIsBlock
+                            ?
+                            ResponseAction.builder()
+                                .block(BlockAction.builder().build())
+                                .build()
+                            : ResponseAction.builder()
+                                .count(CountAction.builder().build())
+                                .build()
+                    )
+                    .build(),
+                this.client::updateApplicationLayerAutomaticResponse);
+        }
+        // case 2: state changed
+        // case 2.1 enabled -> disabled
+        else if (desiredStatus.equals("DISABLED") && currentStatus.equals("ENABLED")) {
+            proxy.injectCredentialsAndInvokeV2(
+                DisableApplicationLayerAutomaticResponseRequest.builder()
+                    .resourceArn(resourceArn)
+                    .build(),
+                this.client::disableApplicationLayerAutomaticResponse);
+        }
+        // case 2.1 disabled -> enabled
+        else if (desiredStatus.equals("ENABLED") && currentStatus.equals("DISABLED")) {
+            proxy.injectCredentialsAndInvokeV2(
+                EnableApplicationLayerAutomaticResponseRequest.builder()
+                    .resourceArn(resourceArn)
+                    .action(
+                        desiredActionIsBlock
+                            ?
+                            ResponseAction.builder()
+                                .block(BlockAction.builder().build())
+                                .build()
+                            : ResponseAction.builder()
+                                .count(CountAction.builder().build())
+                                .build()
+                    )
+                    .build(),
+                this.client::enableApplicationLayerAutomaticResponse);
+        }
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> readProtection(

--- a/aws-shield-protection/src/test/java/software/amazon/shield/protection/UpdateHandlerTest.java
+++ b/aws-shield-protection/src/test/java/software/amazon/shield/protection/UpdateHandlerTest.java
@@ -7,9 +7,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.shield.ShieldClient;
 import software.amazon.awssdk.services.shield.model.ApplicationLayerAutomaticResponseConfiguration;
+import software.amazon.awssdk.services.shield.model.AssociateHealthCheckRequest;
+import software.amazon.awssdk.services.shield.model.AssociateHealthCheckResponse;
 import software.amazon.awssdk.services.shield.model.BlockAction;
 import software.amazon.awssdk.services.shield.model.DescribeProtectionRequest;
 import software.amazon.awssdk.services.shield.model.DescribeProtectionResponse;
+import software.amazon.awssdk.services.shield.model.DisableApplicationLayerAutomaticResponseRequest;
 import software.amazon.awssdk.services.shield.model.EnableApplicationLayerAutomaticResponseRequest;
 import software.amazon.awssdk.services.shield.model.EnableApplicationLayerAutomaticResponseResponse;
 import software.amazon.awssdk.services.shield.model.ListTagsForResourceRequest;
@@ -17,6 +20,9 @@ import software.amazon.awssdk.services.shield.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.shield.model.Protection;
 import software.amazon.awssdk.services.shield.model.ResponseAction;
 import software.amazon.awssdk.services.shield.model.Tag;
+import software.amazon.awssdk.services.shield.model.TagResourceRequest;
+import software.amazon.awssdk.services.shield.model.TagResourceResponse;
+import software.amazon.awssdk.services.shield.model.UpdateApplicationLayerAutomaticResponseRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -26,8 +32,9 @@ import software.amazon.shield.protection.helper.ProtectionTestData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
@@ -39,59 +46,72 @@ public class UpdateHandlerTest {
     private Logger logger;
 
     private UpdateHandler updateHandler;
-    private ResourceModel resourceModel;
 
     @BeforeEach
     public void setup() {
-        this.proxy = mock(AmazonWebServicesClientProxy.class);
-        this.logger = mock(Logger.class);
+        this.proxy = mock(AmazonWebServicesClientProxy.class, withSettings().verboseLogging());
+        this.logger = mock(Logger.class, withSettings().verboseLogging());
 
-        this.updateHandler = new UpdateHandler(mock(ShieldClient.class));
-        this.resourceModel = ProtectionTestData.RESOURCE_MODEL_1;
+        this.updateHandler = new UpdateHandler(mock(ShieldClient.class, withSettings().verboseLogging()));
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
+    public void updateAllFields() {
         final ResourceHandlerRequest<ResourceModel> request =
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(this.resourceModel)
-                        .nextToken(ProtectionTestData.NEXT_TOKEN)
-                        .build();
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(ProtectionTestData.RESOURCE_MODEL_1.toBuilder()
+                    .healthCheckArns(null)
+                    .applicationLayerAutomaticResponseConfiguration(null)
+                    .tags(null)
+                    .build())
+                .desiredResourceState(ProtectionTestData.RESOURCE_MODEL_1)
+                .nextToken(ProtectionTestData.NEXT_TOKEN)
+                .build();
 
-        final DescribeProtectionResponse describeProtectionResponse =
-                DescribeProtectionResponse.builder()
+        when(this.proxy
+            .injectCredentialsAndInvokeV2(any(), any()))
+            .thenAnswer(i -> {
+                if (i.getArgument(0) instanceof DescribeProtectionRequest) {
+                    return DescribeProtectionResponse.builder()
                         .protection(
-                                Protection.builder()
-                                        .name(ProtectionTestData.NAME_1)
-                                        .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
-                                        .protectionArn(ProtectionTestData.PROTECTION_ARN)
-                                        .id(ProtectionTestData.PROTECTION_ID)
-                                        .healthCheckIds(
-                                                ProtectionTestData.HEALTH_CHECK_ID_1,
-                                                ProtectionTestData.HEALTH_CHECK_ID_2)
-                                        .applicationLayerAutomaticResponseConfiguration(
-                                                ApplicationLayerAutomaticResponseConfiguration.builder()
-                                                        .action(
-                                                                ResponseAction.builder()
-                                                                        .block(BlockAction.builder().build())
-                                                                        .build())
-                                                        .status(ProtectionTestData.ENABLED)
-                                                        .build())
+                            Protection.builder()
+                                .name(ProtectionTestData.NAME_1)
+                                .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                                .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                                .id(ProtectionTestData.PROTECTION_ID)
+                                .healthCheckIds(
+                                    ProtectionTestData.HEALTH_CHECK_ID_1,
+                                    ProtectionTestData.HEALTH_CHECK_ID_2)
+                                .applicationLayerAutomaticResponseConfiguration(
+                                    ApplicationLayerAutomaticResponseConfiguration.builder()
+                                        .action(
+                                            ResponseAction.builder()
+                                                .block(BlockAction.builder().build())
+                                                .build())
+                                        .status(ProtectionTestData.ENABLED)
                                         .build())
+                                .build())
                         .build();
-
-        doReturn(EnableApplicationLayerAutomaticResponseResponse.builder().build())
-                .when(this.proxy)
-                .injectCredentialsAndInvokeV2(any(EnableApplicationLayerAutomaticResponseRequest.class), any());
-
-        registerListTags();
-
-        doReturn(describeProtectionResponse)
-                .when(this.proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeProtectionRequest.class), any());
+                } else if (i.getArgument(0) instanceof ListTagsForResourceRequest) {
+                    return ListTagsForResourceResponse.builder()
+                        .tags(
+                            Tag.builder().key("k1").value("v1").build(),
+                            Tag.builder().key("k2").value("v2").build())
+                        .build();
+                } else if (i.getArgument(0) instanceof EnableApplicationLayerAutomaticResponseRequest) {
+                    return EnableApplicationLayerAutomaticResponseResponse.builder().build();
+                } else if (i.getArgument(0) instanceof AssociateHealthCheckRequest) {
+                    return AssociateHealthCheckResponse.builder().build();
+                } else if (i.getArgument(0) instanceof TagResourceRequest) {
+                    assertThat(((TagResourceRequest) i.getArgument(0)).tags().toString()).isEqualTo(
+                        "[Tag(Key=k1, Value=v1), Tag(Key=k2, Value=v2)]");
+                    return TagResourceResponse.builder().build();
+                }
+                throw new AssertionError("unknown invocation: " + i.getArgument(0));
+            });
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
+            = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -103,16 +123,66 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
     }
 
-    private void registerListTags() {
-        ListTagsForResourceResponse tagResponse =
-                ListTagsForResourceResponse.builder()
-                        .tags(
-                                Tag.builder().key("k1").value("v1").build(),
-                                Tag.builder().key("k2").value("v2").build())
-                        .build();
+    @Test
+    public void minimalUpdates() {
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(ResourceModel.builder()
+                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                    .build())
+                .desiredResourceState(ResourceModel.builder()
+                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                    .build())
+                .nextToken(ProtectionTestData.NEXT_TOKEN)
+                .build();
 
-        doReturn(tagResponse)
-                .when(this.proxy)
-                .injectCredentialsAndInvokeV2(any(ListTagsForResourceRequest.class), any());
+        final DescribeProtectionResponse describeProtectionResponse =
+            DescribeProtectionResponse.builder()
+                .protection(
+                    Protection.builder()
+                        .name(ProtectionTestData.NAME_1)
+                        .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                        .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                        .id(ProtectionTestData.PROTECTION_ID)
+                        .build())
+                .build();
+
+        when(this.proxy
+            .injectCredentialsAndInvokeV2(any(), any()))
+            .thenAnswer(i -> {
+                if (i.getArgument(0) instanceof DescribeProtectionRequest) {
+                    return describeProtectionResponse;
+                } else if (i.getArgument(0) instanceof ListTagsForResourceRequest) {
+                    return ListTagsForResourceResponse.builder().build();
+                } else if (
+                    i.getArgument(0) instanceof EnableApplicationLayerAutomaticResponseRequest
+                        || i.getArgument(0) instanceof DisableApplicationLayerAutomaticResponseRequest
+                        || i.getArgument(0) instanceof UpdateApplicationLayerAutomaticResponseRequest
+                ) {
+                    throw new AssertionError("l4 protection must not invoke l7 apis");
+                }
+                throw new AssertionError("unknown invocation: " + i.getArgument(0));
+            });
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
+
+        final ResourceModel expectedReturningModel = ResourceModel.builder()
+            .protectionId(ProtectionTestData.PROTECTION_ID)
+            .name(ProtectionTestData.NAME_1)
+            .protectionArn(ProtectionTestData.PROTECTION_ARN)
+            .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+            .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(expectedReturningModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 }


### PR DESCRIPTION
- Adding many nullish annotations to function parameters
- fixed Read handler to consistently return `null` when array fields are empty
- fixed Update handler may incorrectly call L7 apis on L4 protections
- Added missing updateTags in update handler
- Refactor many function signatures to base on less complex types to reduce coupling
- Updated unit tests covering issues mentioned in this list