### PR TITLE
fix protectiongroup handlers

### DIFF
--- a/aws-shield-common/src/main/java/software/amazon/shield/common/HandlerHelper.java
+++ b/aws-shield-common/src/main/java/software/amazon/shield/common/HandlerHelper.java
@@ -1,14 +1,21 @@
 package software.amazon.shield.common;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import lombok.NonNull;
 import software.amazon.awssdk.services.shield.ShieldClient;
-import software.amazon.awssdk.services.shield.model.InvalidParameterException;
 import software.amazon.awssdk.services.shield.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.shield.model.Tag;
+import software.amazon.awssdk.services.shield.model.TagResourceRequest;
+import software.amazon.awssdk.services.shield.model.UntagResourceRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
@@ -41,6 +48,58 @@ public class HandlerHelper {
             .stream()
             .map(converter)
             .collect(Collectors.toList());
+    }
+
+    public static <T, S> void updateTags(
+        @Nullable final List<? extends T> desiredTags,
+        Function<? super T, String> desiredTagKeyGetter,
+        Function<? super T, String> desiredTagValueGetter,
+        @Nullable final List<? extends S> currentTags,
+        Function<? super S, String> currentTagKeyGetter,
+        Function<? super S, String> currentTagValueGetter,
+        @NonNull final String resourceArn,
+        @NonNull final ShieldClient shieldClient,
+        @NonNull final AmazonWebServicesClientProxy proxy
+    ) {
+
+        final Map<String, String> currentTagsMap = Optional.ofNullable(currentTags)
+            .orElse(Collections.emptyList())
+            .stream()
+            .collect(Collectors.toMap(
+                currentTagKeyGetter,
+                currentTagValueGetter
+            ));
+
+        final List<software.amazon.awssdk.services.shield.model.Tag> tagsToSet = new ArrayList<>();
+
+        Optional.ofNullable(desiredTags).orElse(Collections.emptyList()).forEach(tag -> {
+            final String desiredKey = desiredTagKeyGetter.apply(tag);
+            final String currentValueAtDesiredKey = currentTagsMap.get(desiredKey);
+            final String desiredValue = desiredTagValueGetter.apply(tag);
+            if (!(desiredValue.equals(currentValueAtDesiredKey))) {
+                tagsToSet.add(software.amazon.awssdk.services.shield.model.Tag.builder()
+                    .key(desiredKey)
+                    .value(desiredValue)
+                    .build());
+            }
+            currentTagsMap.remove(desiredKey);
+        });
+
+        final List<String> tagsToRemove = new ArrayList<>(currentTagsMap.keySet());
+
+        if (tagsToSet.size() > 0) {
+            proxy.injectCredentialsAndInvokeV2(TagResourceRequest.builder()
+                .tags(tagsToSet)
+                .resourceARN(resourceArn)
+                .build(), shieldClient::tagResource);
+        }
+
+        if (tagsToRemove.size() > 0) {
+            proxy.injectCredentialsAndInvokeV2(UntagResourceRequest.builder()
+                .tagKeys(tagsToRemove)
+                .resourceARN(resourceArn)
+                .build(), shieldClient::untagResource);
+        }
     }
 
     public static String protectionArnToId(@NonNull final String protectionArn) {

--- a/aws-shield-protection/src/test/java/software/amazon/shield/protection/UpdateHandlerTest.java
+++ b/aws-shield-protection/src/test/java/software/amazon/shield/protection/UpdateHandlerTest.java
@@ -57,17 +57,6 @@ public class UpdateHandlerTest {
 
     @Test
     public void updateAllFields() {
-        final ResourceHandlerRequest<ResourceModel> request =
-            ResourceHandlerRequest.<ResourceModel>builder()
-                .previousResourceState(ProtectionTestData.RESOURCE_MODEL_1.toBuilder()
-                    .healthCheckArns(null)
-                    .applicationLayerAutomaticResponseConfiguration(null)
-                    .tags(null)
-                    .build())
-                .desiredResourceState(ProtectionTestData.RESOURCE_MODEL_1)
-                .nextToken(ProtectionTestData.NEXT_TOKEN)
-                .build();
-
         when(this.proxy
             .injectCredentialsAndInvokeV2(any(), any()))
             .thenAnswer(i -> {
@@ -110,6 +99,16 @@ public class UpdateHandlerTest {
                 throw new AssertionError("unknown invocation: " + i.getArgument(0));
             });
 
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(ProtectionTestData.RESOURCE_MODEL_1.toBuilder()
+                    .healthCheckArns(null)
+                    .applicationLayerAutomaticResponseConfiguration(null)
+                    .tags(null)
+                    .build())
+                .desiredResourceState(ProtectionTestData.RESOURCE_MODEL_1)
+                .nextToken(ProtectionTestData.NEXT_TOKEN)
+                .build();
         final ProgressEvent<ResourceModel, CallbackContext> response
             = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
 
@@ -125,18 +124,6 @@ public class UpdateHandlerTest {
 
     @Test
     public void minimalUpdates() {
-        final ResourceHandlerRequest<ResourceModel> request =
-            ResourceHandlerRequest.<ResourceModel>builder()
-                .previousResourceState(ResourceModel.builder()
-                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
-                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
-                    .build())
-                .desiredResourceState(ResourceModel.builder()
-                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
-                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
-                    .build())
-                .nextToken(ProtectionTestData.NEXT_TOKEN)
-                .build();
 
         final DescribeProtectionResponse describeProtectionResponse =
             DescribeProtectionResponse.builder()
@@ -165,6 +152,19 @@ public class UpdateHandlerTest {
                 }
                 throw new AssertionError("unknown invocation: " + i.getArgument(0));
             });
+
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(ResourceModel.builder()
+                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                    .build())
+                .desiredResourceState(ResourceModel.builder()
+                    .protectionArn(ProtectionTestData.PROTECTION_ARN)
+                    .resourceArn(ProtectionTestData.RESOURCE_ARN_1)
+                    .build())
+                .nextToken(ProtectionTestData.NEXT_TOKEN)
+                .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
             = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);

--- a/aws-shield-protectiongroup/aws-shield-protectiongroup.json
+++ b/aws-shield-protectiongroup/aws-shield-protectiongroup.json
@@ -2,9 +2,15 @@
   "typeName": "AWS::Shield::ProtectionGroup",
   "description": "A grouping of protected resources so they can be handled as a collective. This resource grouping improves the accuracy of detection and reduces false positives.",
   "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-shield.git",
-  "primaryIdentifier": ["/properties/ProtectionGroupArn"],
-  "readOnlyProperties": ["/properties/ProtectionGroupArn"],
-  "createOnlyProperties": ["/properties/ProtectionGroupId"],
+  "primaryIdentifier": [
+    "/properties/ProtectionGroupArn"
+  ],
+  "readOnlyProperties": [
+    "/properties/ProtectionGroupArn"
+  ],
+  "createOnlyProperties": [
+    "/properties/ProtectionGroupId"
+  ],
   "replacementStrategy": "delete_then_create",
   "tagging": {
     "taggable": true,
@@ -12,7 +18,11 @@
     "cloudFormationSystemTags": false
   },
   "additionalProperties": false,
-  "required": ["Aggregation", "Pattern", "ProtectionGroupId"],
+  "required": [
+    "Aggregation",
+    "Pattern",
+    "ProtectionGroupId"
+  ],
   "properties": {
     "ProtectionGroupId": {
       "description": "The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it.",
@@ -28,12 +38,20 @@
     "Aggregation": {
       "description": "Defines how AWS Shield combines resource data for the group in order to detect, mitigate, and report events.\n* Sum - Use the total traffic across the group. This is a good choice for most cases. Examples include Elastic IP addresses for EC2 instances that scale manually or automatically.\n* Mean - Use the average of the traffic across the group. This is a good choice for resources that share traffic uniformly. Examples include accelerators and load balancers.\n* Max - Use the highest traffic from each resource. This is useful for resources that don't share traffic and for resources that share that traffic in a non-uniform way. Examples include Amazon CloudFront and origin resources for CloudFront distributions.",
       "type": "string",
-      "enum": ["SUM", "MEAN", "MAX"]
+      "enum": [
+        "SUM",
+        "MEAN",
+        "MAX"
+      ]
     },
     "Pattern": {
       "description": "The criteria to use to choose the protected resources for inclusion in the group. You can include all resources that have protections, provide a list of resource Amazon Resource Names (ARNs), or include all resources of a specified resource type.",
       "type": "string",
-      "enum": ["ALL", "ARBITRARY", "BY_RESOURCE_TYPE"]
+      "enum": [
+        "ALL",
+        "ARBITRARY",
+        "BY_RESOURCE_TYPE"
+      ]
     },
     "Members": {
       "description": "The Amazon Resource Names (ARNs) of the resources to include in the protection group. You must set this when you set `Pattern` to `ARBITRARY` and you must not set it for any other `Pattern` setting.",
@@ -73,7 +91,10 @@
       "description": "A tag associated with an AWS resource. Tags are key:value pairs that you can use to categorize and manage your resources, for purposes like billing or other management. Typically, the tag key represents a category, such as \"environment\", and the tag value represents a specific value within that category, such as \"test,\" \"development,\" or \"production\". Or you might set the tag key to \"customer\" and the value to the customer name or ID. You can specify one or more tags to add to each AWS resource, up to 50 tags for a resource.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["Key", "Value"],
+      "required": [
+        "Key",
+        "Value"
+      ],
       "properties": {
         "Key": {
           "description": "Part of the key:value pair that defines a tag. You can use a tag key to describe a category of information, such as \"customer.\" Tag keys are case-sensitive.",
@@ -93,31 +114,47 @@
       "description": "The automatic application layer DDoS mitigation settings for a Protection. This configuration determines whether Shield Advanced automatically manages rules in the web ACL in order to respond to application layer events that Shield Advanced determines to be DDoS attacks.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["Action", "Status"],
+      "required": [
+        "Action",
+        "Status"
+      ],
       "properties": {
         "Action": {
           "description": "Specifies the action setting that Shield Advanced should use in the AWS WAF rules that it creates on behalf of the protected resource in response to DDoS attacks. You specify this as part of the configuration for the automatic application layer DDoS mitigation feature, when you enable or update automatic mitigation. Shield Advanced creates the AWS WAF rules in a Shield Advanced-managed rule group, inside the web ACL that you have associated with the resource.",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "Block": {
-              "description": "Specifies that Shield Advanced should configure its AWS WAF rules with the AWS WAF `Block` action.\nYou must specify exactly one action, either `Block` or `Count`.",
+          "oneOf": [
+            {
               "type": "object",
               "additionalProperties": false,
-              "const": {}
+              "properties": {
+                "Count": {
+                  "description": "Specifies that Shield Advanced should configure its AWS WAF rules with the AWS WAF `Count` action.\nYou must specify exactly one action, either `Block` or `Count`.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "const": {}
+                }
+              }
             },
-            "Count": {
-              "description": "Specifies that Shield Advanced should configure its AWS WAF rules with the AWS WAF `Count` action.\nYou must specify exactly one action, either `Block` or `Count`.",
+            {
               "type": "object",
               "additionalProperties": false,
-              "const": {}
+              "properties": {
+                "Block": {
+                  "description": "Specifies that Shield Advanced should configure its AWS WAF rules with the AWS WAF `Block` action.\nYou must specify exactly one action, either `Block` or `Count`.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "const": {}
+                }
+              }
             }
-          }
+          ]
         },
         "Status": {
           "description": "Indicates whether automatic application layer DDoS mitigation is enabled for the protection.",
           "type": "string",
-          "enum": ["ENABLED", "DISABLED"]
+          "enum": [
+            "ENABLED",
+            "DISABLED"
+          ]
         }
       }
     }

--- a/aws-shield-protectiongroup/src/main/java/software/amazon/shield/protectiongroup/ReadHandler.java
+++ b/aws-shield-protectiongroup/src/main/java/software/amazon/shield/protectiongroup/ReadHandler.java
@@ -33,11 +33,15 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
             final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final String protectionGroupArn = model.getProtectionGroupArn();
+        logger.log(String.format("ReadHandler: protectionGroup arn = %s", protectionGroupArn));
+        final String protectionGroupId = HandlerHelper.protectionArnToId(protectionGroupArn);
+        logger.log(String.format("ReadHandler: protectionGroup id = %s", protectionGroupId));
 
         try {
             final DescribeProtectionGroupRequest describeProtectionGroupRequest =
                     DescribeProtectionGroupRequest.builder()
-                            .protectionGroupId(model.getProtectionGroupId())
+                            .protectionGroupId(protectionGroupId)
                             .build();
 
             final DescribeProtectionGroupResponse describeProtectionGroupResponse =
@@ -66,10 +70,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                 result.tags(tags);
             }
 
-            return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                    .resourceModel(result.build())
-                    .status(OperationStatus.SUCCESS)
-                    .build();
+            return ProgressEvent.defaultSuccessHandler(result.build());
 
         } catch (RuntimeException e) {
             logger.log("[ERROR] ProtectionGroup ReadHandler: " + e);

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/CreateHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/CreateHandlerTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
@@ -41,7 +42,7 @@ public class CreateHandlerTest {
     @BeforeEach
     public void setup() {
         this.proxy = mock(AmazonWebServicesClientProxy.class);
-        this.logger = mock(Logger.class);
+        this.logger = mock(Logger.class, withSettings().verboseLogging());
 
         this.createHandler = new CreateHandler(mock(ShieldClient.class));
         this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;

--- a/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/UpdateHandlerTest.java
+++ b/aws-shield-protectiongroup/src/test/java/software/amazon/shield/protectiongroup/UpdateHandlerTest.java
@@ -6,6 +6,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.shield.ShieldClient;
+import software.amazon.awssdk.services.shield.model.DescribeProtectionGroupRequest;
+import software.amazon.awssdk.services.shield.model.DescribeProtectionGroupResponse;
+import software.amazon.awssdk.services.shield.model.DescribeProtectionRequest;
+import software.amazon.awssdk.services.shield.model.DisableApplicationLayerAutomaticResponseRequest;
+import software.amazon.awssdk.services.shield.model.EnableApplicationLayerAutomaticResponseRequest;
+import software.amazon.awssdk.services.shield.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.shield.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.shield.model.ProtectionGroup;
+import software.amazon.awssdk.services.shield.model.UpdateApplicationLayerAutomaticResponseRequest;
 import software.amazon.awssdk.services.shield.model.UpdateProtectionGroupRequest;
 import software.amazon.awssdk.services.shield.model.UpdateProtectionGroupResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -19,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
@@ -35,29 +46,50 @@ public class UpdateHandlerTest {
     @BeforeEach
     public void setup() {
         this.proxy = mock(AmazonWebServicesClientProxy.class);
-        this.logger = mock(Logger.class);
+        this.logger = mock(Logger.class, withSettings().verboseLogging());
 
         this.updateHandler = new UpdateHandler(mock(ShieldClient.class));
         this.resourceModel = ProtectionGroupTestData.RESOURCE_MODEL;
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final ResourceHandlerRequest<ResourceModel> request =
-                ResourceHandlerRequest.<ResourceModel>builder()
-                        .desiredResourceState(this.resourceModel)
-                        .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
-                        .build();
+    public void updateNoFields() {
+        final DescribeProtectionGroupResponse describeProtectionGroupResponse = DescribeProtectionGroupResponse.builder()
+                .protectionGroup(ProtectionGroup.builder()
+                    .resourceType(this.resourceModel.getResourceType())
+                    .protectionGroupId(this.resourceModel.getProtectionGroupId())
+                    .protectionGroupArn(this.resourceModel.getProtectionGroupArn())
+                    .aggregation(this.resourceModel.getAggregation())
+                    .members(this.resourceModel.getMembers())
+                    .pattern(this.resourceModel.getPattern())
+                    .build()
+                ).build();
+        when(this.proxy
+            .injectCredentialsAndInvokeV2(any(), any()))
+            .thenAnswer(i -> {
+                if (i.getArgument(0) instanceof DescribeProtectionGroupRequest) {
+                    return describeProtectionGroupResponse;
+                } else if (i.getArgument(0) instanceof ListTagsForResourceRequest) {
+                    return ListTagsForResourceResponse.builder().build();
+                }
+                throw new AssertionError("unknown invocation: " + i.getArgument(0));
+            });
 
+        final ResourceHandlerRequest<ResourceModel> request =
+            ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(this.resourceModel)
+                .desiredResourceState(this.resourceModel)
+                .nextToken(ProtectionGroupTestData.NEXT_TOKEN)
+                .build();
         final UpdateProtectionGroupResponse updateProtectionGroupResponse =
-                UpdateProtectionGroupResponse.builder()
-                        .build();
+            UpdateProtectionGroupResponse.builder()
+                .build();
 
         doReturn(updateProtectionGroupResponse)
-                .when(this.proxy).injectCredentialsAndInvokeV2(any(UpdateProtectionGroupRequest.class), any());
+            .when(this.proxy).injectCredentialsAndInvokeV2(any(UpdateProtectionGroupRequest.class), any());
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
+            = this.updateHandler.handleRequest(this.proxy, request, null, this.logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);


### PR DESCRIPTION
- Updated Protection schema to use `oneof` for L7 auto response configs
- Fixed ProtectionGroup handlers to pass end-to-end tests. Major changes including:
  - use Arn instead of Ids in read/list handlers
  - support update Tags in update handler

